### PR TITLE
Fetch VRAM from registry

### DIFF
--- a/UpdateHogwarts.ps1
+++ b/UpdateHogwarts.ps1
@@ -16,7 +16,9 @@ if (!(Test-Path $configFile)) {
 }
 
 # Get the users VRAM avaliable in kilobytes
-$vram = Get-WmiObject Win32_VideoController | Select-Object -ExpandProperty AdapterRAM
+$vram = 
+
+$qwMemorySize = (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*" -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue)."HardwareInformation.qwMemorySize"
 
 # Calculate  the amount of VRAM they can use
 $poolSize = [math]::Round($vram / 1MB / 2)


### PR DESCRIPTION
The WMI call is limited to 4GB no matter how much more VRAM the GPU actually has.
Fetching the value from registry results in accurate calculations.

Tested on a 2080Ti 11GB VRAM

Documentation that `Win32_VideoController` only supports uint32 values can be found [here](https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-videocontroller)