### PR TITLE
Add proper INI handling with PSINI functions

### DIFF
--- a/UpdateHogwarts.ps1
+++ b/UpdateHogwarts.ps1
@@ -1,81 +1,459 @@
-$configFile = "$env:LOCALAPPDATA\Hogwarts Legacy\Saved\Config\WindowsNoEditor\Engine.ini"
+# The 2 fuinctions for INI files below is 1:1 copied from http://lipkau.net/PsIni/ version 3.0.1
+Function Out-IniFile {
+    <#
+    .Synopsis
+        Write hash content to INI file
+ 
+    .Description
+        Write hash content to INI file
+ 
+    .Notes
+        Author : Oliver Lipkau <oliver@lipkau.net>
+        Blog : http://oliver.lipkau.net/blog/
+        Source : https://github.com/lipkau/PsIni
+                      http://gallery.technet.microsoft.com/scriptcenter/ea40c1ef-c856-434b-b8fb-ebd7a76e8d91
+ 
+        #Requires -Version 2.0
+ 
+    .Inputs
+        System.String
+        System.Collections.IDictionary
+ 
+    .Outputs
+        System.IO.FileSystemInfo
+ 
+    .Example
+        Out-IniFile $IniVar "C:\myinifile.ini"
+        -----------
+        Description
+        Saves the content of the $IniVar Hashtable to the INI File c:\myinifile.ini
+ 
+    .Example
+        $IniVar | Out-IniFile "C:\myinifile.ini" -Force
+        -----------
+        Description
+        Saves the content of the $IniVar Hashtable to the INI File c:\myinifile.ini and overwrites the file if it is already present
+ 
+    .Example
+        $file = Out-IniFile $IniVar "C:\myinifile.ini" -PassThru
+        -----------
+        Description
+        Saves the content of the $IniVar Hashtable to the INI File c:\myinifile.ini and saves the file into $file
+ 
+    .Example
+        $Category1 = @{“Key1”=”Value1”;”Key2”=”Value2”}
+        $Category2 = @{“Key1”=”Value1”;”Key2”=”Value2”}
+        $NewINIContent = @{“Category1”=$Category1;”Category2”=$Category2}
+        Out-IniFile -InputObject $NewINIContent -FilePath "C:\MyNewFile.ini"
+        -----------
+        Description
+        Creating a custom Hashtable and saving it to C:\MyNewFile.ini
+    .Link
+        Get-IniContent
+    #>
 
-# These are a list of variables it will check exist in the file
-$expectedVariables = @(
-    "r.TextureStreaming=1",
-    "PoolSizeVRAMPercentage=100",
-    "r.Streaming.LimitPoolSizeToVRAM=1",
-    "r.bForceCPUAccessToGPUSkinVerts=True",
-    "r.GTSyncType=1",
-    "r.OneFrameThreadLag=1",
-    "r.FinishCurrentFrame=0"
-)
+    [CmdletBinding()]
+    [OutputType(
+        [System.IO.FileSystemInfo]
+    )]
+    Param(
+        # Adds the output to the end of an existing file, instead of replacing the file contents.
+        [switch]
+        $Append,
 
-if (!(Test-Path $configFile)) {
-    throw "Error: The file $configFile does not exist."
-}
+        # Specifies the file encoding. The default is UTF8.
+        #
+        # Valid values are:
+        # -- ASCII: Uses the encoding for the ASCII (7-bit) character set.
+        # -- BigEndianUnicode: Encodes in UTF-16 format using the big-endian byte order.
+        # -- Byte: Encodes a set of characters into a sequence of bytes.
+        # -- String: Uses the encoding type for a string.
+        # -- Unicode: Encodes in UTF-16 format using the little-endian byte order.
+        # -- UTF7: Encodes in UTF-7 format.
+        # -- UTF8: Encodes in UTF-8 format.
+        [ValidateSet("Unicode", "UTF7", "UTF8", "ASCII", "BigEndianUnicode", "Byte", "String")]
+        [Parameter()]
+        [String]
+        $Encoding = "UTF8",
 
-# Get the users VRAM avaliable in kilobytes
-$vram = (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*" -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue)."HardwareInformation.qwMemorySize"
+        # Specifies the path to the output file.
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {Test-Path $_ -IsValid} )]
+        [Parameter( Position = 0, Mandatory = $true )]
+        [String]
+        $FilePath,
 
-# Calculate  the amount of VRAM they can use
-$poolSize = [math]::Round($vram / 1MB / 2)
+        # Allows the cmdlet to overwrite an existing read-only file. Even using the Force parameter, the cmdlet cannot override security restrictions.
+        [Switch]
+        $Force,
 
-# Check if $poolSize is less than 0 or not defined, just incase the above returns null
-if ($poolSize -lt 0 -or !$poolSize) {
-    $poolSize = 2048
-}
+        # Specifies the Hashtable to be written to the file. Enter a variable that contains the objects or type a command or expression that gets the objects.
+        [Parameter( Mandatory = $true, ValueFromPipeline = $true )]
+        [System.Collections.IDictionary]
+        $InputObject,
 
-# More than 6GB for a texture pool is too much even on a 4090 
-if ($poolSize -gt 6144) {
-    $poolSize = 6144
-}
+        # Passes an object representing the location to the pipeline. By default, this cmdlet does not generate any output.
+        [Switch]
+        $Passthru,
 
-# Add the value for r.Streaming.PoolSize to the expectedVariables list
-$expectedVariables += "r.Streaming.PoolSize=$poolSize"
+        # Adds spaces around the equal sign when writing the key = value
+        [Switch]
+        $Loose,
 
-# Read the contents of the file into an array of lines
-$lines = Get-Content $configFile
+        # Writes the file as "pretty" as possible
+        #
+        # Adds an extra linebreak between Sections
+        [Switch]
+        $Pretty
+    )
 
-# Find the [SystemSettings] section and check if the expected variables exist
-$systemSettingsIndex = $lines.IndexOf("[SystemSettings]")
-$existingVariables = @{}
-if ($systemSettingsIndex -ge 0) {
-    $sectionEndIndex = $lines.Count
-    for ($i = $systemSettingsIndex + 1; $i -lt $lines.Count; $i++) {
-        $line = $lines[$i].Trim()
-        if ($line.StartsWith("[")) {
-            $sectionEndIndex = $i
-            break
+    Begin {
+        Write-Debug "PsBoundParameters:"
+        $PSBoundParameters.GetEnumerator() | ForEach-Object { Write-Debug $_ }
+        if ($PSBoundParameters['Debug']) {
+            $DebugPreference = 'Continue'
         }
-        elseif ($line -notmatch "^\s*;.*" -and $line -match "^(.*)=(.*)$") {
-            $key = $matches[1].Trim()
-            $value = $matches[2].Trim()
-            $existingVariables[$key] = $i
+        Write-Debug "DebugPreference: $DebugPreference"
+
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"
+
+        function Out-Keys {
+            param(
+                [ValidateNotNullOrEmpty()]
+                [Parameter( Mandatory, ValueFromPipeline )]
+                [System.Collections.IDictionary]
+                $InputObject,
+
+                [ValidateSet("Unicode", "UTF7", "UTF8", "ASCII", "BigEndianUnicode", "Byte", "String")]
+                [Parameter( Mandatory )]
+                [string]
+                $Encoding = "UTF8",
+
+                [ValidateNotNullOrEmpty()]
+                [ValidateScript( {Test-Path $_ -IsValid})]
+                [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
+                [Alias("Path")]
+                [string]
+                $FilePath,
+
+                [Parameter( Mandatory )]
+                $Delimiter,
+
+                [Parameter( Mandatory )]
+                $MyInvocation
+            )
+
+            Process {
+                if (!($InputObject.get_keys())) {
+                    Write-Warning ("No data found in '{0}'." -f $FilePath)
+                }
+                Foreach ($key in $InputObject.get_keys()) {
+                    if ($key -match "^Comment\d+") {
+                        Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing comment: $key"
+                        "$($InputObject[$key])" | Out-File -Encoding $Encoding -FilePath $FilePath -Append
+                    }
+                    else {
+                        Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $key"
+                        $InputObject[$key] |
+                            ForEach-Object { "$key$delimiter$_" } |
+                            Out-File -Encoding $Encoding -FilePath $FilePath -Append
+                    }
+                }
+            }
         }
+
+        $delimiter = '='
+        if ($Loose) {
+            $delimiter = ' = '
+        }
+
+        # Splatting Parameters
+        $parameters = @{
+            Encoding = $Encoding;
+            FilePath = $FilePath
+        }
+
+    }
+
+    Process {
+        $extraLF = ""
+
+        if ($Append) {
+            Write-Debug ("Appending to '{0}'." -f $FilePath)
+            $outfile = Get-Item $FilePath
+        }
+        else {
+            Write-Debug ("Creating new file '{0}'." -f $FilePath)
+            $outFile = New-Item -ItemType file -Path $Filepath -Force:$Force
+        }
+
+        if (!(Test-Path $outFile.FullName)) {Throw "Could not create File"}
+
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing to file: $Filepath"
+        foreach ($i in $InputObject.get_keys()) {
+            if (!($InputObject[$i].GetType().GetInterface('IDictionary'))) {
+                #Key value pair
+                Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing key: $i"
+                "$i$delimiter$($InputObject[$i])" | Out-File -Append @parameters
+
+            }
+            elseif ($i -eq $script:NoSection) {
+                #Key value pair of NoSection
+                Out-Keys $InputObject[$i] `
+                    @parameters `
+                    -Delimiter $delimiter `
+                    -MyInvocation $MyInvocation
+            }
+            else {
+                #Sections
+                Write-Verbose "$($MyInvocation.MyCommand.Name):: Writing Section: [$i]"
+
+                # Only write section, if it is not a dummy ($script:NoSection)
+                if ($i -ne $script:NoSection) { "$extraLF[$i]"  | Out-File -Append @parameters }
+                if ($Pretty) {
+                    $extraLF = "`r`n"
+                }
+
+                if ( $InputObject[$i].Count) {
+                    Out-Keys $InputObject[$i] `
+                        @parameters `
+                        -Delimiter $delimiter `
+                        -MyInvocation $MyInvocation
+                }
+
+            }
+        }
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Finished Writing to file: $FilePath"
+    }
+
+    End {
+        if ($PassThru) {
+            Write-Debug ("Returning file due to PassThru argument.")
+            Write-Output (Get-Item $outFile)
+        }
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Function ended"
     }
 }
 
-# Add the [SystemSettings] section if it doesn't exist
-if ($systemSettingsIndex -lt 0) {
-    $lines += ""
-    $lines += "[SystemSettings]"
-    $systemSettingsIndex = $lines.Count - 1
-    $sectionEndIndex = $lines.Count
-}
+Function Get-IniContent {
+    <#
+    .Synopsis
+        Gets the content of an INI file
+ 
+    .Description
+        Gets the content of an INI file and returns it as a hashtable
+ 
+    .Notes
+        Author : Oliver Lipkau <oliver@lipkau.net>
+        Source : https://github.com/lipkau/PsIni
+                      http://gallery.technet.microsoft.com/scriptcenter/ea40c1ef-c856-434b-b8fb-ebd7a76e8d91
+        Version : 1.0.0 - 2010/03/12 - OL - Initial release
+                      1.0.1 - 2014/12/11 - OL - Typo (Thx SLDR)
+                                              Typo (Thx Dave Stiff)
+                      1.0.2 - 2015/06/06 - OL - Improvment to switch (Thx Tallandtree)
+                      1.0.3 - 2015/06/18 - OL - Migrate to semantic versioning (GitHub issue#4)
+                      1.0.4 - 2015/06/18 - OL - Remove check for .ini extension (GitHub Issue#6)
+                      1.1.0 - 2015/07/14 - CB - Improve round-tripping and be a bit more liberal (GitHub Pull #7)
+                                           OL - Small Improvments and cleanup
+                      1.1.1 - 2015/07/14 - CB - changed .outputs section to be OrderedDictionary
+                      1.1.2 - 2016/08/18 - SS - Add some more verbose outputs as the ini is parsed,
+                                                  allow non-existent paths for new ini handling,
+                                                  test for variable existence using local scope,
+                                                  added additional debug output.
+ 
+        #Requires -Version 2.0
+ 
+    .Inputs
+        System.String
+ 
+    .Outputs
+        System.Collections.Specialized.OrderedDictionary
+ 
+    .Example
+        $FileContent = Get-IniContent "C:\myinifile.ini"
+        -----------
+        Description
+        Saves the content of the c:\myinifile.ini in a hashtable called $FileContent
+ 
+    .Example
+        $inifilepath | $FileContent = Get-IniContent
+        -----------
+        Description
+        Gets the content of the ini file passed through the pipe into a hashtable called $FileContent
+ 
+    .Example
+        C:\PS>$FileContent = Get-IniContent "c:\settings.ini"
+        C:\PS>$FileContent["Section"]["Key"]
+        -----------
+        Description
+        Returns the key "Key" of the section "Section" from the C:\settings.ini file
+ 
+    .Link
+        Out-IniFile
+    #>
 
-# Remove any existing variables and add the expected variables to the end of the [SystemSettings] section
-foreach ($var in $expectedVariables) {
-    $varKey = $var.Split("=")[0]
-    $varValue = $var.Split("=")[1]
-    if ($existingVariables.ContainsKey($varKey)) {
-        $lines[$existingVariables[$varKey]] = "$varKey=$varValue"
-    } else {
-        $lines = $lines + "$varKey=$varValue"
+    [CmdletBinding()]
+    [OutputType(
+        [System.Collections.Specialized.OrderedDictionary]
+    )]
+    Param(
+        # Specifies the path to the input file.
+        [ValidateNotNullOrEmpty()]
+        [Parameter( Mandatory = $true, ValueFromPipeline = $true )]
+        [String]
+        $FilePath,
+
+        # Specify what characters should be describe a comment.
+        # Lines starting with the characters provided will be rendered as comments.
+        # Default: ";"
+        [Char[]]
+        $CommentChar = @(";"),
+
+        # Remove lines determined to be comments from the resulting dictionary.
+        [Switch]
+        $IgnoreComments
+    )
+
+    Begin {
+        Write-Debug "PsBoundParameters:"
+        $PSBoundParameters.GetEnumerator() | ForEach-Object { Write-Debug $_ }
+        if ($PSBoundParameters['Debug']) {
+            $DebugPreference = 'Continue'
+        }
+        Write-Debug "DebugPreference: $DebugPreference"
+
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Function started"
+
+        $commentRegex = "^\s*([$($CommentChar -join '')].*)$"
+        $sectionRegex = "^\s*\[(.+)\]\s*$"
+        $keyRegex     = "^\s*(.+?)\s*=\s*(['`"]?)(.*)\2\s*$"
+
+        Write-Debug ("commentRegex is {0}." -f $commentRegex)
+    }
+
+    Process {
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Processing file: $Filepath"
+
+        $ini = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+        #$ini = @{}
+
+        if (!(Test-Path $Filepath)) {
+            Write-Verbose ("Warning: `"{0}`" was not found." -f $Filepath)
+            Write-Output $ini
+        }
+
+        $commentCount = 0
+        switch -regex -file $FilePath {
+            $sectionRegex {
+                # Section
+                $section = $matches[1]
+                Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding section : $section"
+                $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+                $CommentCount = 0
+                continue
+            }
+            $commentRegex {
+                # Comment
+                if (!$IgnoreComments) {
+                    if (!(test-path "variable:local:section")) {
+                        $section = $script:NoSection
+                        $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+                    }
+                    $value = $matches[1]
+                    $CommentCount++
+                    Write-Debug ("Incremented CommentCount is now {0}." -f $CommentCount)
+                    $name = "Comment" + $CommentCount
+                    Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding $name with value: $value"
+                    $ini[$section][$name] = $value
+                }
+                else {
+                    Write-Debug ("Ignoring comment {0}." -f $matches[1])
+                }
+
+                continue
+            }
+            $keyRegex {
+                # Key
+                if (!(test-path "variable:local:section")) {
+                    $section = $script:NoSection
+                    $ini[$section] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+                }
+                $name, $value = $matches[1, 3]
+                Write-Verbose "$($MyInvocation.MyCommand.Name):: Adding key $name with value: $value"
+                if (-not $ini[$section][$name]) {
+                    $ini[$section][$name] = $value
+                }
+                else {
+                    if ($ini[$section][$name] -is [string]) {
+                        $ini[$section][$name] = [System.Collections.ArrayList]::new()
+                        $ini[$section][$name].Add($ini[$section][$name]) | Out-Null
+                        $ini[$section][$name].Add($value) | Out-Null
+                    }
+                    else {
+                        $ini[$section][$name].Add($value) | Out-Null
+                    }
+                }
+                continue
+            }
+        }
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Finished Processing file: $FilePath"
+        Write-Output $ini
+    }
+
+    End {
+        Write-Verbose "$($MyInvocation.MyCommand.Name):: Function ended"
     }
 }
 
-# Write the updated lines back to the file
-Set-Content $configFile -Value $lines
+function Main() {
+    $configFile = "$env:LOCALAPPDATA\Hogwarts Legacy\Saved\Config\WindowsNoEditor\Engine.ini"
 
-Write-Output "Succesfully updated the file $configFile"
+    # These are a list of variables it will check exist in the file
+    $expectedVariables = @("r.TextureStreaming", "1"),
+        @("PoolSizeVRAMPercentage", "100"),
+        @("r.Streaming.LimitPoolSizeToVRAM", "1"),
+        @("r.bForceCPUAccessToGPUSkinVerts", "True"),
+        @("r.GTSyncType", "1"),
+        @("r.OneFrameThreadLag", "1"),
+        @("r.FinishCurrentFrame", "0")
+
+
+    if (!(Test-Path $configFile)) {
+        throw "Error: The file $configFile does not exist."
+    }
+
+    # Get the users VRAM avaliable in kilobytes
+    $vram = (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*" -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue)."HardwareInformation.qwMemorySize"
+
+    # Calculate  the amount of VRAM they can use
+    $poolSize = [math]::Round($vram / 1MB / 2)
+
+    # Add the value for r.Streaming.PoolSize to the expectedVariables list
+    $expectedVariables += , @("r.Streaming.PoolSize", "$poolSize")
+
+    # Load the ini
+    $ini = Get-IniContent $configFile
+
+    $systemSection = "SystemSettings"
+
+    if (!$ini[$systemSection]) {
+        $ini[$systemSection] = New-Object System.Collections.Specialized.OrderedDictionary([System.StringComparer]::OrdinalIgnoreCase)
+    }
+
+    for ($i=0; $i -lt $expectedVariables.length; $i++) {
+        $name = $expectedVariables[$i][0]
+        $value = $expectedVariables[$i][1]
+
+        Write-Output "key $name and value $value setting to $($ini[$systemSection][$name])"
+
+        $ini[$systemSection][$name] = $value
+    }
+
+    Remove-item $configFile
+    # Write the updated ini file
+    $ini | Out-IniFile -FilePath $configFile
+
+    Write-Output "Succesfully updated the file $configFile"
+}
+
+Main

--- a/UpdateHogwarts.ps1
+++ b/UpdateHogwarts.ps1
@@ -429,8 +429,13 @@ function Main() {
     $poolSize = [math]::Round($vram / 1MB / 2)
 
     # Check if $poolSize is less than 0 or not defined, just incase the above returns null 
-    if ($poolSize -lt 0 -or !$poolSize) { 
-        $poolSize = 2048 
+    if ($poolSize -lt 0 -or !$poolSize) {
+        $poolSize = 2048
+    }
+
+    # More than 6GB for a texture pool is too much even on a 4090  
+    if ($poolSize -gt 6144) {
+        $poolSize = 6144
     }
 
     # Add the value for r.Streaming.PoolSize to the expectedVariables list

--- a/UpdateHogwarts.ps1
+++ b/UpdateHogwarts.ps1
@@ -428,6 +428,11 @@ function Main() {
     # Calculate  the amount of VRAM they can use
     $poolSize = [math]::Round($vram / 1MB / 2)
 
+    # Check if $poolSize is less than 0 or not defined, just incase the above returns null 
+    if ($poolSize -lt 0 -or !$poolSize) { 
+        $poolSize = 2048 
+    }
+
     # Add the value for r.Streaming.PoolSize to the expectedVariables list
     $expectedVariables += , @("r.Streaming.PoolSize", "$poolSize")
 

--- a/UpdateHogwarts.ps1
+++ b/UpdateHogwarts.ps1
@@ -459,7 +459,11 @@ function Main() {
         $ini[$systemSection][$name] = $value
     }
 
-    Remove-item $configFile
+    # Backup original config and delete the original
+    Copy-Item $configFile -Destination "$configFile.bak"
+    Write-Output "Copied original config to the file $configFile.bak"
+    Remove-Item $configFile
+
     # Write the updated ini file
     $ini | Out-IniFile -FilePath $configFile
 


### PR DESCRIPTION
This PR adds proper reading and writing of INI files via functions from the PSINI library.
It also backs up the original INI file by copying it to the same path with `.bak` appended to the name.

I tested without a section, section at the start of the file, at the end of the file and 2 `SystemSettings` sections 1 at the start and 1 at the end of the file.

The reason for copying the functions into the script and not importing all of PSINI is simply to keep it in 1 file, not require module installs and there is only need those specific 2 functions.