### PR TITLE
Fixed VRAM Calculation

### DIFF
--- a/UpdateHogwarts.ps1
+++ b/UpdateHogwarts.ps1
@@ -423,10 +423,10 @@ function Main() {
     }
 
     # Get the users VRAM avaliable in kilobytes
-    $vram = (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*" -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue)."HardwareInformation.qwMemorySize"
+    $vram = (Get-ItemProperty -Path "HKLM:\SYSTEM\ControlSet001\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}\0*" -Name HardwareInformation.qwMemorySize -ErrorAction SilentlyContinue)."HardwareInformation.qwMemorySize" | Measure-Object -Maximum
 
     # Calculate  the amount of VRAM they can use
-    $poolSize = [math]::Round($vram / 1MB / 2)
+    $poolSize = [math]::Round($vram.Maximum / 1MB / 2)
 
     # Check if $poolSize is less than 0 or not defined, just incase the above returns null 
     if ($poolSize -lt 0 -or !$poolSize) {


### PR DESCRIPTION
Using the most recent implementation. When this is ran the script will throw an error when the script tries to run the needed calculation. 

![image](https://user-images.githubusercontent.com/54543335/218268138-4cc7cec4-9526-4ce9-b4fa-30be973e7318.png)

It is also worth noting that the recommended implementation will return multiple valuables when ran on a system with multiple GPUs. For example on my system there is the iGPU which returns a value of 536870912. My rtx 3080 with a value of 10737418240 and my rtx 3060 with a value of 12884901888.

![image](https://user-images.githubusercontent.com/54543335/218268200-562a890e-c196-44cf-b32a-bce09f8cffd6.png)

Based on the current implementation the script will always set the r.Streaming.PoolSize to 2048 based off of using the iGPU. As having multiple dedicated GPUs is very uncommon it may be as simple as to take the maximum value as this would cause the script not use to the iGPU and use the value for whichever card has the highest vram. While this is not a complete fix for someone in my case that has multiple GPUs installed this will fix the problem for people with an iGPU and GPU. 

From my testing, this will also fix the op_Division error. 